### PR TITLE
Fix License

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@napi-rs/canvas": "^0.1.58",
     "async-mutex": "^0.5.0",


### PR DESCRIPTION
In package.json the default ISC is currently in use. The project uses MIT license and updating package.json to reflect that